### PR TITLE
- closing tag for error_container_tag missing

### DIFF
--- a/lib/HTML/FormFu/Role/Element/Field.pm
+++ b/lib/HTML/FormFu/Role/Element/Field.pm
@@ -1059,6 +1059,10 @@ sub _string_errors {
         push @error_html, sprintf qq{<%s%s>%s</%s>},
             $render->{error_tag},
             process_attrs( $error->{attributes} ),
+# works for Text
+#            process_attrs( $render->{error_attributes} ),
+# works for Select
+#            process_attrs( $self->{error_attributes} ),
             $error->{message},
             $render->{error_tag},
             ;

--- a/share/templates/tt/xhtml/field_layout_errors
+++ b/share/templates/tt/xhtml/field_layout_errors
@@ -12,5 +12,5 @@
 %][%    IF self.error_container_tag.defined 
 %]
 </[% self.error_container_tag 
-%][%    END 
+%]>[%   END 
 %][% END %]

--- a/t-aggregate/elements/error_attributes_failing_test.select-with-attrs.yml
+++ b/t-aggregate/elements/error_attributes_failing_test.select-with-attrs.yml
@@ -1,0 +1,12 @@
+---
+elements:
+    - type: Select
+      name: foo
+      error_attributes:
+          class: 'class-error_attributes'
+      options:
+        - [1, One]
+        - [2, Two]
+      constraints:
+        - type: AutoSet
+          message: 'test'

--- a/t-aggregate/elements/error_attributes_failing_test.select.yml
+++ b/t-aggregate/elements/error_attributes_failing_test.select.yml
@@ -1,0 +1,10 @@
+---
+elements:
+    - type: Select
+      name: foo
+      options:
+        - [1, One]
+        - [2, Two]
+      constraints:
+        - type: AutoSet
+          message: 'test'

--- a/t-aggregate/elements/error_attributes_failing_test.t
+++ b/t-aggregate/elements/error_attributes_failing_test.t
@@ -1,0 +1,123 @@
+use strict;
+use warnings;
+
+use Test::More tests => 4;
+
+use HTML::FormFu;
+
+{
+    my $form = HTML::FormFu->new(
+        { tt_args => { INCLUDE_PATH => 'share/templates/tt/xhtml' } } );
+
+    $form->load_config_file('t-aggregate/elements/error_attributes_failing_test.text-with-attrs.yml');
+
+    $form->process({
+        foo => 3333,
+    });
+
+    is( "$form", <<EOF );
+<form action="" method="post">
+<div>
+<span class="class-error_attributes">test</span>
+<label>Foo</label>
+<input name="foo" type="text" value="3333" />
+</div>
+</form>
+EOF
+}
+
+{
+    my $form = HTML::FormFu->new(
+        { tt_args => { INCLUDE_PATH => 'share/templates/tt/xhtml' } } );
+
+    $form->default_args({
+        elements => {
+            Field => {
+                error_attributes => {
+                    class => 'class-error_attributes',
+                },
+                attributes => {
+                    class => 'class-attributes', # used in the error_tag!
+                },
+            },
+            layout => [qw/label errors field comment javascript/],
+        },
+    });
+
+
+    $form->load_config_file('t-aggregate/elements/error_attributes_failing_test.text.yml');
+
+    $form->process({
+        foo => 3333,
+    });
+
+    is( "$form", <<EOF );
+<form action="" method="post">
+<div>
+<span class="class-error_attributes">test</span>
+<label>Foo</label>
+<input name="foo" type="text" value="3333" class="class-attributes" />
+</div>
+</form>
+EOF
+}
+
+{
+    my $form = HTML::FormFu->new(
+        { tt_args => { INCLUDE_PATH => 'share/templates/tt/xhtml' } } );
+
+    $form->load_config_file('t-aggregate/elements/error_attributes_failing_test.select-with-attrs.yml');
+
+    $form->process({
+        foo => 3333,
+    });
+
+    is( "$form", <<EOF );
+<form action="" method="post">
+<div>
+<span class="class-error_attributes">test</span>
+<select name="foo">
+<option value="1">One</option>
+<option value="2">Two</option>
+</select>
+</div>
+</form>
+EOF
+}
+
+{
+    my $form = HTML::FormFu->new(
+        { tt_args => { INCLUDE_PATH => 'share/templates/tt/xhtml' } } );
+
+    $form->default_args({
+        elements => {
+            Field => {
+                error_attributes => {
+                    class => 'class-error_attributes',
+                },
+                attributes => {
+                    class => 'class-attributes',
+                },
+            },
+            layout => [qw/label errors field comment javascript/],
+        },
+    });
+
+    $form->load_config_file('t-aggregate/elements/error_attributes_failing_test.select.yml');
+
+    $form->process({
+        foo => 3333,
+    });
+
+    is( "$form", <<EOF );
+<form action="" method="post">
+<div>
+<span class="class-error_attributes">test</span>
+<select name="foo" class="class-attributes">
+<option value="1">One</option>
+<option value="2">Two</option>
+</select>
+</div>
+</form>
+EOF
+}

--- a/t-aggregate/elements/error_attributes_failing_test.text-with-attrs.yml
+++ b/t-aggregate/elements/error_attributes_failing_test.text-with-attrs.yml
@@ -1,0 +1,11 @@
+---
+elements:
+    - type: Text
+      name: foo
+      label: Foo
+      error_attributes:
+          class: 'class-error_attributes'
+      constraints:
+        - type: MaxLength
+          max: 3
+          message: 'test'

--- a/t-aggregate/elements/error_attributes_failing_test.text.yml
+++ b/t-aggregate/elements/error_attributes_failing_test.text.yml
@@ -1,0 +1,11 @@
+---
+elements:
+    - type: Text
+      name: foo
+      label: Foo
+      error_attributes:
+          class: 'class-error_attributes'
+      constraints:
+        - type: MaxLength
+          max: 3
+          message: 'test'


### PR DESCRIPTION
using error_container_tag + tt won't work, because of a missing > at the closing tag

also i have a problem with using error_attributes. Changing in the same file error.attributes to self.error_attributes work, but then the behavior when a error_container_tag is set is broken. I don't get what is the problem there, but error_attributes and error_container_attributes won't work properly.


Example:
error_attributes => { class => 'help-block', },
=>
```
<span>Error</span>
```

VS

error_container_tag => 'div',
error_container_attributes => { class => 'test', },
error_attributes => { class => 'help-block', },
=>
```
<div class="help-block">
<span class="help-block">Error</span>
</div>
```